### PR TITLE
Various QOL improvements to the Plasticity Bridge Blender add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Various QOL improvements to the Plasticity Bridge Blender add-on:
 
 - Consolidated Mark Sharp and Mark Sharp at boundaries into a single operator (AutoMarkEdgesOperator) with options to mark selection as Hard Edges or UV Seams (Mark Sharp, Mark Seam).
 - Added functionality: Smart Edges Marking - Only works on entire mesh selection and not individually selected polygons that are part of a Plasticity group. Will mark edges as Sharp or UV seam using the logic of MarkSharpEdgesForPlasticityGroupsWithSplitNormalsOperator.
-- Added functionality to arbitrarily select polygons that are part of Plasticity surface groups and mark their boundaries instead of applying changes to entire mesh (for mark as Sharp and with added UV seams functionality).
+- Added functionality to arbitrarily select polygons that are part of Plasticity surface groups and mark their boundaries instead of marking boundaries of individual Plasticity surfaces (for mark as Sharp and with added UV seams functionality).
 - Added functionality to merge existing UV seams based on arbitrary Plasticity group polygon selection.
 - Added functionality to select Plasticity groups edges.
 - Changed default port from 8080 to 8090 (conflicting with some AV software).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # plasticity-blender-addon
 
+Experimental Plasticity blender addon to send facet data over websockets
+
 Various QOL improvements to the Plasticity Bridge Blender add-on:
 
 - Consolidated Mark Sharp and Mark Sharp at boundaries into a single operator (AutoMarkEdgesOperator) with options to mark selection as Hard Edges or UV Seams (Mark Sharp, Mark Seam).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Various QOL improvements to the Plasticity Bridge Blender add-on:
 - Added functionality to merge existing UV seams based on arbitrary Plasticity group polygon selection.
 - Added functionality to select Plasticity groups edges.
 - Changed default port from 8080 to 8090 (conflicting with some AV software).
-- Exposed prop_surface_angle_tolerance parameter, allowing users to have more control when re-meshing and wanting to have smooth curved objects at a small scale. Works well in combination when using small values for Min Width.
+- Exposed prop_surface_angle_tolerance parameter, allowing users to have more control when re-meshing and wanting to keep smooth curved objects at a small scale. Works well in combination when using small values for Min Width.
 
 Always make sure that you remesh the imported CAD data from Plasticity at least once, otherwise most of the Brigde features won't work as expected.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Various QOL improvements to the Plasticity Bridge Blender add-on:
 - Added functionality to merge existing UV seams based on arbitrary Plasticity group polygon selection.
 - Added functionality to select Plasticity groups edges.
 - Changed default port from 8080 to 8090 (conflicting with some AV software).
-- Exposed prop_surface_angle_tolerance parameter, allowing to have more control when re-meshing and wanting to have smooth curved objects at a small scale. Works well in combination when using small values for Min Width.
+- Exposed prop_surface_angle_tolerance parameter, allowing users to have more control when re-meshing and wanting to have smooth curved objects at a small scale. Works well in combination when using small values for Min Width.
 
 Always make sure that you remesh the imported CAD data from Plasticity at least once, otherwise most of the Brigde features won't work as expected.

--- a/README.md
+++ b/README.md
@@ -10,5 +10,8 @@ Various QOL improvements to the Plasticity Bridge Blender add-on:
 - Added functionality to merge existing UV seams based on arbitrary Plasticity group polygon selection.
 - Added functionality to select Plasticity groups edges.
 - Changed default port from 8080 to 8090 (conflicting with some AV software).
+- Exposed prop_surface_angle_tolerance parameter, allowing to have more control when re-meshing and wanting to have smooth curved objects at a small scale. Works well in combination when using small values for Min Width.
+
+Always make sure that you re-mesh the imported CAD data from Plasticity, otherwise most of the features won't work as expected.
 
 Always make sure that you remesh the imported CAD data from Plasticity at least once, otherwise most of the Brigde features won't work as expected.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Various QOL improvements to the Plasticity Bridge Blender add-on:
 - Added functionality to merge existing UV seams based on arbitrary Plasticity group polygon selection.
 - Added functionality to select Plasticity groups edges.
 - Changed default port from 8080 to 8090 (conflicting with some AV software).
+
+Always make sure that you remesh the imported CAD data from Plasticity at least once, otherwise most of the features won't work as expected.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Various QOL improvements to the Plasticity Bridge Blender add-on:
 - Added functionality to merge existing UV seams based on arbitrary Plasticity group polygon selection.
 - Added functionality to select Plasticity groups edges.
 - Changed default port from 8080 to 8090 (conflicting with some AV software).
-- Exposed prop_surface_angle_tolerance parameter, allowing users to have more control when re-meshing and wanting to keep small objects having smooth curves.
+- Exposed prop_surface_angle_tolerance parameter, allowing users to have more control when re-meshing and wanting to keep small objects having smooth curves. Works well in combination when using small values for Min Width.
 
 Always make sure that you remesh the imported CAD data from Plasticity at least once, otherwise most of the Brigde features won't work as expected.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Various QOL improvements to the Plasticity Bridge Blender add-on:
 
 - Consolidated Mark Sharp and Mark Sharp at boundaries into a single operator (AutoMarkEdgesOperator) with options to mark selection as Hard Edges or UV Seams (Mark Sharp, Mark Seam).
 - Added functionality: Smart Edges Marking - Only works on entire mesh selection and not individually selected polygons that are part of a Plasticity group. Will mark edges as Sharp or UV seam using the logic of MarkSharpEdgesForPlasticityGroupsWithSplitNormalsOperator.
-- Added functionality to arbitrarily select polygons that are part of Plasticity surface groups instead of applying changes to entire mesh.
+- Added functionality to arbitrarily select polygons that are part of Plasticity surface groups instead of applying changes to entire mesh (for mark as Sharp and with added UV seams functionality).
 - Added functionality to merge existing UV seams based on arbitrary Plasticity group polygon selection.
 - Added functionality to select Plasticity groups edges.
 - Changed default port from 8080 to 8090 (conflicting with some AV software).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # plasticity-blender-addon
 
-Experimental Plasticity blender addon to send facet data over websockets
+Various QOL improvements to the Plasticity Bridge Blender add-on:
+
+- Consolidated Mark Sharp and Mark Sharp at boundaries into a single operator (AutoMarkEdgesOperator) with options to mark selection as Hard Edges or UV Seams (Mark Sharp, Mark Seam).
+- Added functionality: Smart Edges Marking - Only works on entire mesh selection and not individually selected polygons that are part of a Plasticity group. Will mark edges as Sharp or UV seam using the logic of MarkSharpEdgesForPlasticityGroupsWithSplitNormalsOperator.
+- Added functionality to arbitrarily select polygons that are part of Plasticity surface groups instead of applying changes to entire mesh.
+- Added functionality to merge existing UV seams based on arbitrary Plasticity group polygon selection.
+- Added functionality to select Plasticity groups edges.
+- Changed default port from 8080 to 8090 (conflicting with some AV software).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Various QOL improvements to the Plasticity Bridge Blender add-on:
 - Added functionality to merge existing UV seams based on arbitrary Plasticity group polygon selection.
 - Added functionality to select Plasticity groups edges.
 - Changed default port from 8080 to 8090 (conflicting with some AV software).
-- Exposed prop_surface_angle_tolerance parameter, allowing users to have more control when re-meshing and wanting to keep smooth curved objects at a small scale. Works well in combination when using small values for Min Width.
+- Exposed prop_surface_angle_tolerance parameter, allowing users to have more control when re-meshing and wanting to keep small objects having smooth curves.
 
 Always make sure that you remesh the imported CAD data from Plasticity at least once, otherwise most of the Brigde features won't work as expected.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,4 @@ Various QOL improvements to the Plasticity Bridge Blender add-on:
 - Changed default port from 8080 to 8090 (conflicting with some AV software).
 - Exposed prop_surface_angle_tolerance parameter, allowing to have more control when re-meshing and wanting to have smooth curved objects at a small scale. Works well in combination when using small values for Min Width.
 
-Always make sure that you re-mesh the imported CAD data from Plasticity, otherwise most of the features won't work as expected.
-
 Always make sure that you remesh the imported CAD data from Plasticity at least once, otherwise most of the Brigde features won't work as expected.

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Various QOL improvements to the Plasticity Bridge Blender add-on:
 - Added functionality to select Plasticity groups edges.
 - Changed default port from 8080 to 8090 (conflicting with some AV software).
 
-Always make sure that you remesh the imported CAD data from Plasticity at least once, otherwise most of the features won't work as expected.
+Always make sure that you remesh the imported CAD data from Plasticity at least once, otherwise most of the Brigde features won't work as expected.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Various QOL improvements to the Plasticity Bridge Blender add-on:
 
 - Consolidated Mark Sharp and Mark Sharp at boundaries into a single operator (AutoMarkEdgesOperator) with options to mark selection as Hard Edges or UV Seams (Mark Sharp, Mark Seam).
 - Added functionality: Smart Edges Marking - Only works on entire mesh selection and not individually selected polygons that are part of a Plasticity group. Will mark edges as Sharp or UV seam using the logic of MarkSharpEdgesForPlasticityGroupsWithSplitNormalsOperator.
-- Added functionality to arbitrarily select polygons that are part of Plasticity surface groups instead of applying changes to entire mesh (for mark as Sharp and with added UV seams functionality).
+- Added functionality to arbitrarily select polygons that are part of Plasticity surface groups and mark their boundaries instead of applying changes to entire mesh (for mark as Sharp and with added UV seams functionality).
 - Added functionality to merge existing UV seams based on arbitrary Plasticity group polygon selection.
 - Added functionality to select Plasticity groups edges.
 - Changed default port from 8080 to 8090 (conflicting with some AV software).

--- a/__init__.py
+++ b/__init__.py
@@ -7,8 +7,8 @@ from .handler import SceneHandler
 bl_info = {
     "name": "Plasticity",
     "description": "A bridge to Plasticity",
-    "author": "Nick Kallen",
-    "version": (1, 0),
+    "author": "Nick Kallen, User129863",
+    "version": (1, 0, 1),
     "blender": (2, 80, 0),
     "location": "View3D > Sidebar > Plasticity",
     "category": "Object",

--- a/__init__.py
+++ b/__init__.py
@@ -39,11 +39,15 @@ def register():
     bpy.utils.register_class(ui.RefacetButton)
     bpy.utils.register_class(ui.PlasticityPanel)
     bpy.utils.register_class(operators.SelectByFaceIDOperator)
+    bpy.utils.register_class(operators.SelectByFaceIDEdgeOperator)
     bpy.utils.register_class(
         operators.MarkSharpEdgesForPlasticityGroupsWithSplitNormalsOperator)
     bpy.utils.register_class(
         operators.MarkSharpEdgesForPlasticityGroupsOperator)
-    bpy.utils.register_class(operators.PaintPlasticityFacesOperator)
+    bpy.utils.register_class(operators.AutoMarkEdgesOperator)
+    bpy.utils.register_class(operators.MergeUVSeams)
+    #bpy.utils.register_class(operators.MergeHardEdges)
+    bpy.utils.register_class(operators.PaintPlasticityFacesOperator)    
     # bpy.utils.register_class(operators.SetPlasticityOriginToOriginOperator)
     # bpy.utils.register_class(operators.ClearPlasticityOriginOperator)
 
@@ -51,7 +55,7 @@ def register():
     bpy.types.VIEW3D_MT_edit_mesh_select_similar.append(select_similar)
 
     bpy.types.Scene.prop_plasticity_server = bpy.props.StringProperty(
-        name="Server", default="localhost:8080")
+        name="Server", default="localhost:8090")
     bpy.types.Scene.prop_plasticity_facet_tolerance = bpy.props.FloatProperty(
         name="Tolerance", default=0.01, min=0.0001, max=1.0)
     bpy.types.Scene.prop_plasticity_facet_angle = bpy.props.FloatProperty(
@@ -74,6 +78,10 @@ def register():
         name="Max Width", default=0.0, min=0, unit="LENGTH")
     bpy.types.Scene.prop_plasticity_unit_scale = bpy.props.FloatProperty(
         name="Unit Scale", default=1.0, min=0.0001, max=1000.0)
+    bpy.types.Scene.prop_plasticity_surface_angle_tolerance = bpy.props.FloatProperty(
+        name="Surface Angle tolerance", default=0.35, min=0.0001, max=1.0)        
+    bpy.types.Scene.mark_seam = bpy.props.BoolProperty(name="Mark Seam")        
+    bpy.types.Scene.mark_sharp = bpy.props.BoolProperty(name="Mark Sharp")     
 
     print("Plasticity client registered")
 
@@ -89,10 +97,14 @@ def unregister():
     bpy.utils.unregister_class(ui.UnsubscribeAllButton)
     bpy.utils.unregister_class(ui.RefacetButton)
     bpy.utils.unregister_class(operators.SelectByFaceIDOperator)
+    bpy.utils.unregister_class(operators.SelectByFaceIDEdgeOperator)
     bpy.utils.unregister_class(
         operators.MarkSharpEdgesForPlasticityGroupsWithSplitNormalsOperator)
     bpy.utils.unregister_class(
         operators.MarkSharpEdgesForPlasticityGroupsOperator)
+    bpy.utils.unregister_class(operators.AutoMarkEdgesOperator)
+    bpy.utils.unregister_class(operators.MergeUVSeams)
+    #bpy.utils.unregister_class(operators.MergeHardEdges)
     bpy.utils.unregister_class(operators.PaintPlasticityFacesOperator)
     # bpy.utils.unregister_class(operators.SetPlasticityOriginToOriginOperator)
     # bpy.utils.unregister_class(operators.ClearPlasticityOriginOperator)
@@ -109,7 +121,10 @@ def unregister():
     del bpy.types.Scene.prop_plasticity_facet_min_width
     del bpy.types.Scene.prop_plasticity_facet_max_width
     del bpy.types.Scene.prop_plasticity_unit_scale
-
+    del bpy.types.Scene.prop_plasticity_surface_angle_tolerance  
+    del bpy.types.Scene.mark_seam
+    del bpy.types.Scene.mark_sharp           
+    
 
 if __name__ == "__main__":
     register()

--- a/operators.py
+++ b/operators.py
@@ -5,7 +5,6 @@ import bmesh
 import bpy
 import mathutils
 
-
 class SelectByFaceIDOperator(bpy.types.Operator):
     bl_idname = "mesh.select_by_plasticity_face_id"
     bl_label = "Select by Plasticity Face ID"
@@ -50,33 +49,118 @@ class SelectByFaceIDOperator(bpy.types.Operator):
             self.report({'ERROR'}, "No face_ids found")
             return {'CANCELLED'}
 
-        active_face = bm.faces.active
-        if not active_face:
-            self.report({'ERROR'}, "No active face selected")
-            return {'CANCELLED'}
+        # Collect group IDs of all selected faces
+        selected_group_ids = set()
+        for face in bm.faces:
+            if face.select:
+                loop_idx = face.loops[0].index
+                for i in range(0, len(groups), 2):
+                    group_start = groups[i + 0]
+                    group_count = groups[i + 1]
+                    if loop_idx >= group_start and loop_idx < group_start + group_count:
+                        selected_group_ids.add(i)
+                        break
 
-        loop_idx = active_face.loops[0].index
-
-        group_id = -1
-        for i in range(0, len(groups), 2):
-            group_start = groups[i + 0]
-            group_count = groups[i + 1]
-            if loop_idx >= group_start and loop_idx < group_start + group_count:
-                group_id = i
-                break
-
-        if group_id == -1:
-            self.report({'ERROR'}, "No group found for face")
-            return {'CANCELLED'}
-
-        group_start = groups[group_id + 0]
-        group_count = groups[group_id + 1]
-
+        # Select all faces belonging to any of the selected group IDs
         for face in bm.faces:
             loop_start = face.loops[0].index
-            if loop_start >= group_start and loop_start < group_start + group_count:
-                face.select = True
+            for group_id in selected_group_ids:
+                group_start = groups[group_id + 0]
+                group_count = groups[group_id + 1]
+                if loop_start >= group_start and loop_start < group_start + group_count:
+                    face.select = True
+                    break
 
+        bmesh.update_edit_mesh(mesh)
+        return {'FINISHED'}
+
+class SelectByFaceIDEdgeOperator(bpy.types.Operator):
+    bl_idname = "mesh.select_by_plasticity_face_id_edge"
+    bl_label = "Select by Plasticity Face ID (Edge)"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        if context.mode != 'EDIT_MESH':
+            return False
+        obj = context.active_object
+        if not obj or not obj.select_get() or obj.type != 'MESH' or "plasticity_id" not in obj.keys():
+            return False
+        active_poly_index = obj.data.polygons.active
+        if active_poly_index is None:
+            return False
+        active_poly = obj.data.polygons[active_poly_index]
+        if not active_poly.select:
+            return False
+        return True
+
+    def get_boundary_edges_for_group_ids(self, bm, mesh, selected_group_ids):
+        groups = mesh["groups"]
+        boundary_edges = set()
+        for face in bm.faces:
+            loop_start = face.loops[0].index
+            for group_id in selected_group_ids:
+                group_start = groups[group_id + 0]
+                group_count = groups[group_id + 1]
+                if loop_start >= group_start and loop_start < group_start + group_count:
+                    for edge in face.edges:
+                        if edge in boundary_edges:
+                            boundary_edges.remove(edge)
+                        else:
+                            boundary_edges.add(edge)
+                    break
+        return boundary_edges
+
+    def get_selected_group_ids(self, context):
+        obj = context.active_object
+        mesh = obj.data
+        bm = bmesh.from_edit_mesh(mesh)
+        groups = mesh["groups"]
+        selected_group_ids = set()
+        for face in bm.faces:
+            if face.select:
+                loop_idx = face.loops[0].index
+                for i in range(0, len(groups), 2):
+                    group_start = groups[i + 0]
+                    group_count = groups[i + 1]
+                    if loop_idx >= group_start and loop_idx < group_start + group_count:
+                        selected_group_ids.add(i)
+                        break
+        return selected_group_ids
+
+    def execute(self, context):
+        obj = context.object
+        bpy.ops.object.mode_set(mode='EDIT')
+        mesh = obj.data
+        bm = bmesh.from_edit_mesh(mesh)
+        groups = mesh["groups"]
+        
+        if not groups:
+            self.report({'ERROR'}, "No groups found")
+            return {'CANCELLED'}
+        
+        face_ids = mesh["face_ids"]
+        if not face_ids:
+            self.report({'ERROR'}, "No face_ids found")
+            return {'CANCELLED'}
+
+        selected_group_ids = self.get_selected_group_ids(context)
+        boundary_edges = self.get_boundary_edges_for_group_ids(bm, mesh, selected_group_ids)
+        
+        # Unselect the faces in selected_group_ids
+        for face in bm.faces:
+            loop_start = face.loops[0].index
+            for group_id in selected_group_ids:
+                group_start = groups[group_id + 0]
+                group_count = groups[group_id + 1]
+                if loop_start >= group_start and loop_start < group_start + group_count:
+                    face.select = False
+                    break
+
+        # Select the boundary edges
+        for edge in boundary_edges:
+            edge.select = True
+                    
         bmesh.update_edit_mesh(mesh)
         return {'FINISHED'}
 
@@ -154,6 +238,9 @@ class MarkSharpEdgesForPlasticityGroupsOperator(bpy.types.Operator):
     bl_idname = "mesh.mark_sharp_edges_for_plasticity"
     bl_label = "Mark Sharp Edges for Plasticity Groups"
     bl_options = {'REGISTER', 'UNDO'}
+    
+    mark_sharp: bpy.props.BoolProperty(name="Mark Sharp", default=True)
+    mark_seam: bpy.props.BoolProperty(name="Mark Seam", default=False)
 
     @classmethod
     def poll(cls, context):
@@ -194,12 +281,189 @@ class MarkSharpEdgesForPlasticityGroupsOperator(bpy.types.Operator):
         bm.verts.ensure_lookup_table()
         bm.faces.ensure_lookup_table()
 
-        for edge in face_boundary_edges(groups, mesh, bm):
-            edge.smooth = False
+        for edge in face_boundary_edges(groups, mesh, bm):        
+            if self.mark_sharp:        
+                edge.smooth = False
+            
+            if self.mark_seam:    
+                edge.seam = True
 
         bm.to_mesh(obj.data)
         bm.free()
+   
+class MergeUVSeams(bpy.types.Operator):
+    bl_idname = "mesh.merge_uv_seams"
+    bl_label = "Merge UV Seams"
+    bl_options = {'REGISTER', 'UNDO'}    
 
+    def execute(self, context):
+        bpy.ops.mesh.select_linked(delimit={'SEAM'})
+        bpy.ops.mesh.mark_seam(clear=True)
+        bpy.ops.mesh.region_to_loop()
+        bpy.ops.mesh.mark_seam(clear=False)
+        bpy.ops.mesh.select_all(action='DESELECT')
+        bpy.ops.mesh.select_mode(use_extend=False, use_expand=False, type='FACE')
+
+        return {'FINISHED'}   
+
+class AutoMarkEdgesOperator(bpy.types.Operator):
+    bl_idname = "mesh.auto_mark_edges"
+    bl_label = "Auto Mark Edges"
+    bl_options = {'REGISTER', 'UNDO'}
+    
+    Smart_Edges_Marking: bpy.props.BoolProperty(name="Smart Edges Marking", default=False)
+    mark_sharp: bpy.props.BoolProperty(name="Mark Sharp", default=True)
+    mark_seam: bpy.props.BoolProperty(name="Mark Seam", default=False)
+
+    @classmethod
+    def poll(cls, context):
+        return (
+            any("plasticity_id" in obj.keys() and obj.type == 'MESH' for obj in context.selected_objects) 
+            or (context.mode == 'EDIT_MESH' and context.active_object and "plasticity_id" in context.active_object.keys())
+        )
+
+    def execute(self, context):
+        prev_obj_mode = bpy.context.object.mode
+
+        if context.mode == 'EDIT_MESH':
+            selected_group_ids = self.get_selected_group_ids(context)
+            self.mark_edges_for_selected_faces(context, selected_group_ids)
+        else:
+            for obj in context.selected_objects:
+                if obj.type != 'MESH':
+                    continue
+                if not "plasticity_id" in obj.keys():
+                    continue
+                              
+                mesh = obj.data
+                bpy.ops.object.mode_set(mode='OBJECT')
+
+                if "plasticity_id" not in obj.keys():
+                    self.report({'ERROR'}, "Object doesn't have a plasticity_id attribute.")
+                    return {'CANCELLED'}
+                
+                groups = mesh["groups"]
+                self.mark_sharp_edges(obj, groups)
+
+        bpy.ops.object.mode_set(mode=prev_obj_mode)
+        return {'FINISHED'}
+
+    def get_selected_group_ids(self, context):
+        obj = context.active_object
+        mesh = obj.data
+        bm = bmesh.from_edit_mesh(mesh)
+        groups = mesh["groups"]
+        selected_group_ids = set()
+
+        for face in bm.faces:
+            if face.select:
+                loop_idx = face.loops[0].index
+                for i in range(0, len(groups), 2):
+                    group_start = groups[i + 0]
+                    group_count = groups[i + 1]
+                    if loop_idx >= group_start and loop_idx < group_start + group_count:
+                        selected_group_ids.add(i)
+                        break
+        return selected_group_ids
+
+    def get_boundary_edges_for_group_ids(self, bm, mesh, selected_group_ids):
+        groups = mesh["groups"]
+        boundary_edges = set()
+        
+        for face in bm.faces:
+            loop_start = face.loops[0].index
+            for group_id in selected_group_ids:
+                group_start = groups[group_id + 0]
+                group_count = groups[group_id + 1]
+                if loop_start >= group_start and loop_start < group_start + group_count:
+                    for edge in face.edges:
+                        if edge in boundary_edges:
+                            boundary_edges.remove(edge)
+                        else:
+                            boundary_edges.add(edge)
+                    break
+        return boundary_edges
+
+    def mark_edges_for_selected_faces(self, context, selected_group_ids):
+        obj = context.active_object
+        mesh = obj.data
+        bm = bmesh.from_edit_mesh(mesh)
+        
+        boundary_edges = self.get_boundary_edges_for_group_ids(bm, mesh, selected_group_ids)
+        
+        for edge in boundary_edges:
+            if self.mark_sharp:
+                edge.smooth = False
+            if self.mark_seam:
+                edge.seam = True
+
+    def mark_sharp_edges(self, obj, groups):
+        mesh = obj.data
+        bm = bmesh.new()
+        mesh.calc_normals_split()
+        bm.from_mesh(mesh)
+        bm.edges.ensure_lookup_table()
+        bm.verts.ensure_lookup_table()
+        bm.faces.ensure_lookup_table()
+        loops = mesh.loops
+        
+        all_face_boundary_edges = set()
+        face_boundary_edges = set()
+        group_idx = 0
+        group_start = groups[group_idx * 2 + 0]
+        group_count = groups[group_idx * 2 + 1]
+
+        for poly in mesh.polygons:
+            loop_start = poly.loop_start
+            if loop_start >= group_start + group_count:
+                all_face_boundary_edges.update(face_boundary_edges)
+                group_idx += 1
+                group_start = groups[group_idx * 2 + 0]
+                group_count = groups[group_idx * 2 + 1]
+                face_boundary_edges = set()
+
+            face = bm.faces[poly.index]
+            for edge in face.edges:
+                if edge in face_boundary_edges:
+                    face_boundary_edges.remove(edge)
+                else:
+                    face_boundary_edges.add(edge)
+        all_face_boundary_edges.update(face_boundary_edges)
+
+        split_edges = set()
+        
+        if self.Smart_Edges_Marking:            
+            for vert in bm.verts:
+                for edge in vert.link_edges:
+                    loops_for_vert_and_edge = []
+                    for face in edge.link_faces:
+                        for loop in face.loops:
+                            if loop.vert == vert:
+                                loops_for_vert_and_edge.append(loop)
+                    if len(loops_for_vert_and_edge) != 2:
+                        continue
+                    loop1, loop2 = loops_for_vert_and_edge
+                    normal1 = loops[loop1.index].normal
+                    normal2 = loops[loop2.index].normal
+                    if are_normals_different(normal1, normal2):
+                        split_edges.add(edge)
+        
+        for edge in all_face_boundary_edges:
+            if self.mark_sharp:
+                if self.Smart_Edges_Marking and edge in split_edges:
+                    edge.smooth = False
+                elif not self.Smart_Edges_Marking:
+                    edge.smooth = False
+                    
+            if self.mark_seam:
+                if self.Smart_Edges_Marking and edge in split_edges:
+                    edge.seam = True
+                elif not self.Smart_Edges_Marking:
+                    edge.seam = True
+
+
+        bm.to_mesh(obj.data)
+        bm.free()
 
 def face_boundary_edges(groups, mesh, bm):
     all_face_boundary_edges = set()

--- a/operators.py
+++ b/operators.py
@@ -296,6 +296,13 @@ class MergeUVSeams(bpy.types.Operator):
     bl_label = "Merge UV Seams"
     bl_options = {'REGISTER', 'UNDO'}    
 
+    @classmethod
+    def poll(cls, context):        
+        if context.mode != 'EDIT_MESH':
+            return False
+        if not active_poly.select:
+            return False    
+            
     def execute(self, context):
         bpy.ops.mesh.select_linked(delimit={'SEAM'})
         bpy.ops.mesh.mark_seam(clear=True)

--- a/ui.py
+++ b/ui.py
@@ -2,7 +2,7 @@ import bpy
 import math
 
 from .__init__ import plasticity_client
-
+from .client import FacetShapeType
 
 class ConnectButton(bpy.types.Operator):
     bl_idname = "wm.connect_button"
@@ -92,6 +92,7 @@ class RefacetButton(bpy.types.Operator):
 
     def execute(self, context):
         prop_tolerance = context.scene.prop_plasticity_facet_tolerance
+        prop_surface_angle_tolerance = context.scene.prop_plasticity_surface_angle_tolerance
         prop_angle = context.scene.prop_plasticity_facet_angle
         prop_max_sides = 3 if context.scene.prop_plasticity_facet_tri_or_ngon == "TRI" else 128
         prop_plane_angle = math.pi / 4.0 if (prop_max_sides > 4) else 0
@@ -102,12 +103,12 @@ class RefacetButton(bpy.types.Operator):
         if context.scene.prop_plasticity_ui_show_advanced_facet:
             prop_min_width = context.scene.prop_plasticity_facet_min_width
             prop_max_width = context.scene.prop_plasticity_facet_max_width
-            if prop_max_width < prop_min_width:
-                prop_max_width = prop_min_width
+            #if prop_max_width < prop_min_width:
+             #   prop_max_width = prop_min_width
             # NOTE: it is possible the user wants to do this but this will almost certain overwhelm the server and blender!
-            if 0 < prop_max_width < 0.02:
-                prop_max_width = 0.02
-            curve_chord_max = prop_max_width * math.sqrt(0.5)
+            #if 0 < prop_max_width < 0.02:
+             #   prop_max_width = 0.02
+            #curve_chord_max = prop_max_width * math.sqrt(0.5)
 
         plasticity_ids_by_filename = {}
         for obj in context.selected_objects:
@@ -118,8 +119,20 @@ class RefacetButton(bpy.types.Operator):
                     obj["plasticity_id"])
 
         for filename, plasticity_ids in plasticity_ids_by_filename.items():
-            plasticity_client.refacet_some(filename, plasticity_ids, curve_chord_tolerance=prop_tolerance, min_width=prop_min_width, max_width=prop_max_width,
-                                           surface_plane_tolerance=prop_tolerance, curve_chord_angle=prop_angle, surface_plane_angle=prop_angle, max_sides=prop_max_sides, plane_angle=prop_plane_angle, curve_chord_max=curve_chord_max)
+            plasticity_client.refacet_some(filename, 
+                                           plasticity_ids,
+                                           relative_to_bbox=True,                                           
+                                           curve_chord_tolerance=prop_tolerance, 
+                                           curve_chord_angle=prop_angle,
+                                           surface_plane_tolerance=prop_tolerance,
+                                           surface_plane_angle=prop_surface_angle_tolerance,
+                                           match_topology=True,
+                                           max_sides=prop_max_sides,
+                                           plane_angle=prop_plane_angle,
+                                           min_width=prop_min_width, 
+                                           max_width=prop_max_width,                                           
+                                           curve_chord_max=curve_chord_max,
+                                           shape=FacetShapeType.CUT)
 
         return {'FINISHED'}
 
@@ -181,16 +194,32 @@ class PlasticityPanel(bpy.types.Panel):
                          text="Min width")
                 box.prop(scene, "prop_plasticity_facet_max_width",
                          text="Max width")
+                box.prop(scene, "prop_plasticity_curve_chord_tolerance",
+                         text="Curve Chord Tolerance")
+                box.prop(scene, "prop_plasticity_surface_angle_tolerance",
+                         text="Surface Angle Tolerance")                          
             layout.separator()
 
             box = layout.box()
             box.label(text="Utilities:")
-            box.operator("mesh.mark_sharp_edges_for_plasticity_with_split_normals",
-                         text="Mark sharp")
-            box.operator("mesh.mark_sharp_edges_for_plasticity",
-                         text="Mark sharp at all faces")
-            box.operator("mesh.paint_plasticity_faces",
-                         text="Paint Plasticity Faces")
-            box.separator()
+            #box.operator("mesh.mark_sharp_edges_for_plasticity_with_split_normals",
+             #            text="Mark sharp")
+            #box.operator("mesh.mark_sharp_edges_for_plasticity",
+             #            text="Mark sharp at all faces")            
+            #box.prop(scene, "mark_sharp")
+            #box.prop(scene, "mark_seam") 
+
+            box.operator("mesh.auto_mark_edges", text="Auto Mark Edges")
+            box.operator("mesh.merge_uv_seams", text="Merge UV Seams")
+            #box.operator("mesh.merge_hard_edges", text="Merge Hard Edges")
+            #box.prop(scene, "mark_sharp")
+            #box.prop(scene, "mark_seam")             
             box.operator("mesh.select_by_plasticity_face_id",
-                         text="Select similar faces")
+                         text="Select Plasticity Face(s)")
+            box.operator("mesh.select_by_plasticity_face_id_edge",
+                         text="Select Plasticity Edges")                                                  
+            box.operator("mesh.paint_plasticity_faces",
+                         text="Paint Plasticity Faces")            
+
+                         
+                         


### PR DESCRIPTION
- Consolidated Mark Sharp and Mark Sharp at boundaries into a single operator (AutoMarkEdgesOperator) with options to mark selection as Hard Edges or UV Seams (Mark Sharp, Mark Seam).
- Added functionality: Smart Edges Marking - Only works on entire mesh selection and not individually selected polygons that are part of a Plasticity group. Will mark edges as Sharp or UV seam using the logic of MarkSharpEdgesForPlasticityGroupsWithSplitNormalsOperator.
- Added functionality to arbitrarily select polygons that are part of Plasticity surface groups and mark their boundaries instead of marking boundaries of individual Plasticity surfaces (for mark as Sharp and with added UV seams functionality).- 
- Added functionality to merge existing UV seams based on arbitrary Plasticity group polygon selection.
- Added functionality to select Plasticity groups edges.
- Changed default port from 8080 to 8090 (conflicting with some AV software).
- Exposed prop_surface_angle_tolerance parameter, allowing users to have more control when re-meshing and wanting to keep small objects having smooth curves. Works well in combination when using small values for Min Width.